### PR TITLE
use codap types for initial data, do not track dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # production
 /build
+/dist
 
 # OS
 .DS_Store

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -52,14 +52,18 @@ export const App = () => {
       setDataContext(createDC.values);
     }
     if (existingDataContext?.success || createDC?.success) {
-      createNC = await createNewCollection(kDataContextName, "Pets", [{name: "type", type: "string"}, {name: "number", type: "number"}]);
-      createI = await createItems(kDataContextName, [ {type: "dog", number: 5},
-                                      {type: "cat", number: 4},
-                                      {type: "fish", number: 20},
-                                      {type: "horse", number: 1},
-                                      {type: "bird", number: 8},
-                                      {type: "hamster", number: 3}
-                                    ]);
+      createNC = await createNewCollection(kDataContextName, "Pets", [
+        { name: "animal", type: "categorical" },
+        { name: "count", type: "numeric" }
+      ]);
+      createI = await createItems(kDataContextName, [
+        { animal: "dog", count: 5 },
+        { animal: "cat", count: 4 },
+        { animal: "fish", count: 20 },
+        { animal: "horse", count: 1 },
+        { animal: "bird", count: 2 },
+        { animal: "snake", count: 1 }
+      ]);
     }
 
     setCodapResponse(`Data context created: ${JSON.stringify(createDC)}


### PR DESCRIPTION
This makes some changes to the initial data created in the starter plugin:
- new attributes are given types `"numeric"` and `"categorical"` (instead of `"number"` and `"string"`)
- The Pet attribute "type" was changed to "animal" to disambiguate from the notion of a CODAP "type"
- The Pet attribute "number" was changed to "count" to disambiguate from the type `number`. 
- added `/dist` to `.gitignore`

@tealefristoe, @pjanik,  @dougmartin I think this makes sense to do?  It prevents the initial error in the base plugin on V3, and I tested it within V2 and it works the same as it did before.  It is not yet completely feature complete within v3, but the initial error on any kind of data set creation is gone. 