### PR TITLE
fix listeners and action examples

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,7 +7,7 @@ import {
   getAllItems,
   getDataContext,
   initializePlugin,
-  addComponentListener,
+  addDataContextChangeListener,
   ClientNotification,
 } from "@concord-consortium/codap-plugin-api";
 import "./App.css";
@@ -31,16 +31,16 @@ export const App = () => {
     // this is an example of how to add a notification listener to a CODAP component
     // for more information on listeners and notifications, see
     // https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#documentchangenotice
-    const createTableListener = (listenerRes: ClientNotification) => {
-      if (listenerRes.values.operation === "open case table") {
-        setListenerNotification("A case table has been created");
+    const casesUpdatedListener = (listenerRes: ClientNotification) => {
+      if (listenerRes.values.operation === "updateCases") {
+        setListenerNotification(JSON.stringify(listenerRes.values.result));
       }
     };
-    addComponentListener(createTableListener);
+    addDataContextChangeListener(kDataContextName, casesUpdatedListener);
   }, []);
 
   const handleOpenTable = async () => {
-    const res = await createTable(dataContext, kDataContextName);
+    const res = await createTable(kDataContextName);
     setCodapResponse(res);
   };
 
@@ -66,10 +66,11 @@ export const App = () => {
       ]);
     }
 
-    setCodapResponse(`Data context created: ${JSON.stringify(createDC)}
-    New collection created: ${JSON.stringify(createNC)}
-    New items created: ${JSON.stringify(createI)}`
-                    );
+    setCodapResponse(`
+      Data context created: ${JSON.stringify(createDC)}
+      New collection created: ${JSON.stringify(createNC)}
+      New items created: ${JSON.stringify(createI)}
+    `);
   };
 
   const handleGetResponse = async () => {
@@ -84,7 +85,7 @@ export const App = () => {
         <button onClick={handleCreateData}>
           Create some data
         </button>
-        <button onClick={handleOpenTable}>
+        <button onClick={handleOpenTable} disabled={!dataContext}>
           Open Table
         </button>
         <button onClick={handleGetResponse}>


### PR DESCRIPTION
This fixes some demonstration features so that they work in both CODAP V2 and V3

- use `addDataContextChangeListener` to add a listener for `updateCases`, this provides an example event broadcast by both v2 and v3
- do not enable the Open Table button unless there is a dataContext created
- Pass a string to `createTable`, instead of the dataContext object (an object is only supported as a parameter in V2, a string of the dataContext.name is supported in both)
