### PR TITLE
CODAP-121 Update readme, webpack config, and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CODAP Plugin Starter Project
 
-This is a bare-bones React project, created with the `--typescript` version of [Create React App](https://github.com/facebook/create-react-app), and left un-ejected. This is simply a trivial React view with the libraries for using the [CODAP Plugin API](https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API).
+This is a bare-bones React project. It contains a simple React view with the libraries for using the [CODAP Plugin API](https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API).
 
 ## Development
 
@@ -57,55 +57,22 @@ This is a bare-bones React project, created with the `--typescript` version of [
 
 ## Testing the plugin in CODAP
 
-Currently there is no trivial way to load a plugin running on a local server with `http` into the online CODAP, which forces `https`. One simple solution is to download the latest `build_[...].zip` file from https://codap.concord.org/releases/zips/, extract it to a folder and run it locally. If CODAP is running on port 8080, and this project is running by default on 3000, you can go to
+There are two ways to test the plugin in CODAP:
+- running it locally on https and use the deployed CODAP
+- running it and CODAP locally on http
 
-http://127.0.0.1:8080/static/dg/en/cert/index.html?di=http://localhost:3000
+### HTTPS
+1. Start the plugin with `npm run start:secure`. You need to first setup a local http certificate if you haven't done so: https://github.com/concord-consortium/codap/blob/main/v3/README.md#run-using-https
+2. Run CODAP v2 or v3 with the `di` parameter:
+    - v2: https://codap.concord.org/app/?di=https://localhost:8080/
+    - v3: https://codap3.concord.org/?di=https://localhost:8080/
 
-to see the plugin running in CODAP.
+### HTTP
+1. Start plugin webserver `npm start` (it will be on 8080 by default)
+2. Setup a local webserver running CODAP.
+    - v2: Download the latest `build_[...].zip` file https://codap.concord.org/releases/zips/. Extract the zip to a folder and run it with a local webserver. For example `npx httpserver -p 8081`
+    - v3: Checkout the v3 source, install the dependencies, and start the dev server: https://github.com/concord-consortium/codap/blob/main/v3/README.md#initial-steps. The dev server should automatically choose the next avaiable port which would normally be 8081
+3. Open CODAP with the plugin embedded in it: http://localhost:8081/static/dg/en/cert/index.html?di=http://localhost:8080
 
-# Create React App Readme
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
-## Available Scripts
-
-In the project directory, you can run:
-
-### `npm start`
-
-Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.<br>
-You will also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.<br>
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.<br>
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br>
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+For further information on [CODAP Data Interactive Plugin API](https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API).

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "start": "webpack serve --no-https",
     "start:secure": "webpack serve",
-    "start:secure:no-certs": "webpack serve --no-https-request-cert",
+    "start:secure:no-certs": "webpack serve --server-options-cert-reset --server-options-key-reset",
     "build": "npm-run-all lint:build build:webpack",
     "build:webpack": "webpack --mode production",
     "build:top-test": "cross-env DEPLOY_PATH=specific/release/ webpack --mode production --output-path top-test/specific/release && cp top-test/specific/release/index-top.html top-test/",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,9 +21,15 @@ module.exports = (env, argv) => {
     devServer: {
       static: 'dist',
       hot: true,
-      https: {
-        key: path.resolve(os.homedir(), '.localhost-ssl/localhost.key'),
-        cert: path.resolve(os.homedir(), '.localhost-ssl/localhost.pem'),
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      },
+      server: {
+        type: 'https',
+        options: {
+          key: path.resolve(os.homedir(), '.localhost-ssl/localhost.key'),
+          cert: path.resolve(os.homedir(), '.localhost-ssl/localhost.pem'),
+        }
       },
     },
     devtool: devMode ? 'eval-cheap-module-source-map' : 'source-map',


### PR DESCRIPTION
This updates the readme in similar ways to this old PR: https://github.com/concord-consortium/codap-plugin-starter-project/pull/2:
- it removes the create react app boilerplate
- it documents how to run the plugin embedded inside of CODAP

It updates the webpack config to use the modern version of configuring the dev server. It also sets up the CORS header on the dev server so URLs from this dev server can be loaded in CODAP, for example when CODAP loads a dataset from a URL sent by the plugin.

It updates the npm `start:secure:no-certs` script so it runs again without error.
